### PR TITLE
Add git installation

### DIFF
--- a/cookbooks/keystone/recipes/setup.rb
+++ b/cookbooks/keystone/recipes/setup.rb
@@ -20,9 +20,9 @@ execute "apt-get-update" do
 end
 
 required_packages = [
-  "python-dev", "python3-dev", "libxml2-dev", "libxslt1-dev", "libsasl2-dev",
-  "libsqlite3-dev", "libssl-dev", "libldap2-dev", "libffi-dev",
-  "build-essential", "libxslt-dev",
+  "git", "python-dev", "python3-dev", "libxml2-dev", "libxslt1-dev",
+  "libsasl2-dev", "libsqlite3-dev", "libssl-dev", "libldap2-dev",
+  "libffi-dev", "build-essential", "libxslt-dev",
 ]
 required_packages.each do |pkg|
   package pkg do


### PR DESCRIPTION
It does not worked on no proxy environment (Error is following), because git command is not installed. 
So, I fixup this error.

Error:

<pre>
$ vagrant up
:
==> default: [2015-12-06T01:25:18+00:00] ERROR: Running exception handlers
==> default: [2015-12-06T01:25:18+00:00] ERROR: Exception handlers complete
==> default: [2015-12-06T01:25:18+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
==> default: [2015-12-06T01:25:18+00:00] ERROR: execute[git keystone] (keystone::setup line 42) had an error: Errno::ENOENT: No such file or directory - git
==> default: [2015-12-06T01:25:18+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
</pre>
