### PR TITLE
Enabled to switch method that registering the keystone initial data

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,6 +65,7 @@ local_config = {
   'swift_specs_repo_branch' => (ENV['SWIFTSPECS_REPO_BRANCH'] || 'master'),
   'keystone_repo' => (ENV['KEYSTONE_REPO'] || 'git://github.com/openstack/keystone.git'),
   'keystone_repo_branch' => (ENV['KEYSTONE_REPO_BRANCH'] || 'master'),
+  'keystone_register_data_method' => (ENV['KEYSTONE_REGISTER_DATA_METHOD'] || 'openstack-client'),
   'keystonemiddleware_repo' => (ENV['KEYSTONEMIDDLEWARE_REPO'] || 'git://github.com/openstack/keystonemiddleware.git'),
   'keystonemiddleware_repo_branch' => (ENV['KEYSTONEMIDDLEWARE_REPO_BRANCH'] || 'master'),
   'openstackclient_repo' => (ENV['OPENSTACKCLIENT_REPO'] || 'git://github.com/openstack/python-openstackclient.git'),

--- a/cookbooks/keystone/files/default/register_keystone_initial_data.sh
+++ b/cookbooks/keystone/files/default/register_keystone_initial_data.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# Copyright (c) 2015 Fujitsu, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "===> Start initial settings for swift function_test"
+WORK_DIR="/vagrant/scripts"
+
+# Prepare
+apt-get install -y jq
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+
+# Get Token
+TOKEN=ADMIN
+
+# Create Region(RegionOne)
+REGION_ID="RegionOne"
+sed -e s/@REGION_ID@/${REGION_ID}/g -e 's/@DESCRIPTION@/Region one/g' ${WORK_DIR}/region_template.json >${WORK_DIR}/regionone_region.json
+curl -i -X POST http://127.0.0.1:5000/v3/regions -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json" -H "Accept: application/json" -T ${WORK_DIR}/regionone_region.json
+
+
+# Create project (demo, admin, service)
+sed -e s/@PROJECT_NAME@/demo/g -e s/@DOMAIN_ID@/default/g ${WORK_DIR}/project_template.json >${WORK_DIR}/demo_project.json
+sed -e s/@PROJECT_NAME@/admin/g -e s/@DOMAIN_ID@/default/g ${WORK_DIR}/project_template.json >${WORK_DIR}/admin_project.json
+sed -e s/@PROJECT_NAME@/service/g -e s/@DOMAIN_ID@/default/g ${WORK_DIR}/project_template.json >${WORK_DIR}/service_project.json
+
+DEMO_PROJECT_ID=$(curl -sS -X POST http://127.0.0.1:5000/v3/projects -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json" -H "Accept: application/json" -T ${WORK_DIR}/demo_project.json | jq .project.id |tr -d '"')
+ADMIN_PROJECT_ID=$(curl -sS -X POST http://127.0.0.1:5000/v3/projects -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json" -H "Accept: application/json" -T ${WORK_DIR}/admin_project.json | jq .project.id |tr -d '"')
+SERVICE_PROJECT_ID=$(curl -sS -X POST http://127.0.0.1:5000/v3/projects -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json" -H "Accept: application/json" -T ${WORK_DIR}/service_project.json | jq .project.id |tr -d '"')
+
+# Create User (demo, admin, swift)
+sed -e s/@USER_NAME@/demo/g -e s/@PASSWORD@/demo/g -e s/@DOMAIN_ID@/default/g ${WORK_DIR}/user_template.json >${WORK_DIR}/demo_user.json
+sed -e s/@USER_NAME@/admin/g -e s/@PASSWORD@/admin_password/g -e s/@DOMAIN_ID@/default/g ${WORK_DIR}/user_template.json >${WORK_DIR}/admin_user.json
+sed -e s/@USER_NAME@/swift/g -e s/@PASSWORD@/swift_password/g -e s/@DOMAIN_ID@/default/g ${WORK_DIR}/user_template.json >${WORK_DIR}/swift_user.json
+
+DEMO_ID=$(curl -sS -X POST http://127.0.0.1:35357/v3/users -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json" -H "Accept: application/json" -T ${WORK_DIR}/demo_user.json | jq .user.id |tr -d '"')
+ADMIN_ID=$(curl -sS -X POST http://127.0.0.1:35357/v3/users -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json" -H "Accept: application/json" -T ${WORK_DIR}/admin_user.json | jq .user.id |tr -d '"')
+SWIFT_ID=$(curl -sS -X POST http://127.0.0.1:35357/v3/users -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json" -H "Accept: application/json" -T ${WORK_DIR}/swift_user.json | jq .user.id |tr -d '"')
+
+# Create Role (admin, _member_)
+sed -e s/@ROLE_NAME@/admin/g ${WORK_DIR}/role_template.json >${WORK_DIR}/admin_role.json
+sed -e 's/@ROLE_NAME@/_member_/g' ${WORK_DIR}/role_template.json >${WORK_DIR}/member_role.json
+ADMIN_ROLE_ID=$(curl -sS -X POST http://127.0.0.1:5000/v3/roles -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json" -H "Accept: application/json" -T ${WORK_DIR}/admin_role.json | jq .role.id |tr -d '"')
+MEMBER_ROLE_ID=$(curl -sS -X POST http://127.0.0.1:5000/v3/roles -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json" -H "Accept: application/json" -T ${WORK_DIR}/member_role.json | jq .role.id |tr -d '"')
+
+############################
+# Grant role to project user
+#  admin  -> admin,_member_
+#  swift -> admin,_member_
+############################
+curl -sS -X PUT http://127.0.0.1:35357/v3/projects/${ADMIN_PROJECT_ID}/users/${ADMIN_ID}/roles/${MEMBER_ROLE_ID} -H "X-Auth-Token: ${TOKEN}"
+curl -sS -X PUT http://127.0.0.1:35357/v3/projects/${ADMIN_PROJECT_ID}/users/${ADMIN_ID}/roles/${ADMIN_ROLE_ID} -H "X-Auth-Token: ${TOKEN}"
+curl -sS -X PUT http://127.0.0.1:35357/v3/projects/${SERVICE_PROJECT_ID}/users/${SWIFT_ID}/roles/${MEMBER_ROLE_ID} -H "X-Auth-Token: ${TOKEN}"
+curl -sS -X PUT http://127.0.0.1:35357/v3/projects/${SERVICE_PROJECT_ID}/users/${SWIFT_ID}/roles/${ADMIN_ROLE_ID} -H "X-Auth-Token: ${TOKEN}"
+
+############################
+# Create Service
+############################
+sed -e s/@TYPE@/identity/g -e s/@NAME@/keystone/g -e 's/@DESCRIPTION@/OpenStack Identity/g' ${WORK_DIR}/service_template.json >${WORK_DIR}/service_keystone.json
+sed -e 's/@TYPE@/object-store/g' -e s/@NAME@/swift/g -e 's/@DESCRIPTION@/OpenStack Object Storage/g' ${WORK_DIR}/service_template.json >${WORK_DIR}/service_swift.json
+
+KEYSTONE_SERVICE_ID=`curl -sS -X POST http://127.0.0.1:35357/v3/services -T ${WORK_DIR}/service_keystone.json -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json" | jq .service.id |tr -d '"'`
+SWIFT_SERVICE_ID=`curl -sS -X POST http://127.0.0.1:35357/v3/services -T ${WORK_DIR}/service_swift.json -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json"| jq .service.id |tr -d '"'`
+
+############################
+# Create endpoint list
+############################
+sed -e s/@INTERFACE@/admin/g -e 's/@NAME@/keystone/g' -e 's/@TYPE@/identity/g' -e "s/@REGION_ID@/${REGION_ID}/g" -e 's+@URL@+http://127.0.0.1:35357/v2.0+g' -e "s/@SERVICE_ID@/${KEYSTONE_SERVICE_ID}/g" ${WORK_DIR}/endpoint_template.json >${WORK_DIR}/ep_admin_keystone.json
+sed -e s/@INTERFACE@/internal/g -e 's/@NAME@/keystone/g' -e 's/@TYPE@/identity/g' -e "s/@REGION_ID@/${REGION_ID}/g" -e 's+@URL@+http://127.0.0.1:35357/v2.0+g' -e "s/@SERVICE_ID@/${KEYSTONE_SERVICE_ID}/g" ${WORK_DIR}/endpoint_template.json >${WORK_DIR}/ep_public_keystone.json
+sed -e s/@INTERFACE@/public/g -e 's/@NAME@/keystone/g' -e 's/@TYPE@/identity/g' -e "s/@REGION_ID@/${REGION_ID}/g" -e 's+@URL@+http://127.0.0.1:35357/v2.0+g' -e "s/@SERVICE_ID@/${KEYSTONE_SERVICE_ID}/g" ${WORK_DIR}/endpoint_template.json >${WORK_DIR}/ep_internal_keystone.json
+
+curl -sS -X POST http://127.0.0.1:35357/v3/endpoints -T ${WORK_DIR}/ep_admin_keystone.json -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json"
+curl -sS -X POST http://127.0.0.1:35357/v3/endpoints -T ${WORK_DIR}/ep_public_keystone.json -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json"
+curl -sS -X POST http://127.0.0.1:35357/v3/endpoints -T ${WORK_DIR}/ep_internal_keystone.json -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json"
+
+sed -e s/@INTERFACE@/admin/g -e 's/@NAME@/swift/g' -e 's/@TYPE@/object-store/g' -e "s/@REGION_ID@/${REGION_ID}/g" -e 's+@URL@+http://127.0.0.1:8080/v1/AUTH_%(tenant_id)s+g' -e "s/@SERVICE_ID@/${SWIFT_SERVICE_ID}/g" ${WORK_DIR}/endpoint_template.json >${WORK_DIR}/ep_admin_swift.json
+sed -e s/@INTERFACE@/internal/g -e 's/@NAME@/swift/g' -e 's/@TYPE@/object-store/g' -e "s/@REGION_ID@/${REGION_ID}/g" -e 's+@URL@+http://127.0.0.1:8080/v1/AUTH_%(tenant_id)s+g' -e "s/@SERVICE_ID@/${SWIFT_SERVICE_ID}/g" ${WORK_DIR}/endpoint_template.json >${WORK_DIR}/ep_internal_swift.json
+sed -e s/@INTERFACE@/public/g -e 's/@NAME@/swift/g' -e 's/@TYPE@/object-store/g' -e "s/@REGION_ID@/${REGION_ID}/g" -e 's+@URL@+http://127.0.0.1:8080/v1/AUTH_%(tenant_id)s+g' -e "s/@SERVICE_ID@/${SWIFT_SERVICE_ID}/g" ${WORK_DIR}/endpoint_template.json >${WORK_DIR}/ep_public_swift.json
+
+curl -sS -X POST http://127.0.0.1:35357/v3/endpoints -T ${WORK_DIR}/ep_admin_swift.json -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json"
+curl -sS -X POST http://127.0.0.1:35357/v3/endpoints -T ${WORK_DIR}/ep_public_swift.json -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json"
+curl -sS -X POST http://127.0.0.1:35357/v3/endpoints -T ${WORK_DIR}/ep_internal_swift.json -H "X-Auth-Token: ${TOKEN}" -H "Content-Type: application/json"
+
+# cleanup
+rm -f ${WORK_DIR}/demo_project.json
+rm -f ${WORK_DIR}/admin_project.json
+rm -f ${WORK_DIR}/service_project.json
+rm -f ${WORK_DIR}/demo_user.json
+rm -f ${WORK_DIR}/admin_user.json
+rm -f ${WORK_DIR}/swift_user.json
+rm -f ${WORK_DIR}/admin_role.json
+rm -f ${WORK_DIR}/member_role.json
+rm -f ${WORK_DIR}/service_keystone.json
+rm -f ${WORK_DIR}/service_swift.json
+rm -f ${WORK_DIR}/regionone_region.json
+rm -f ${WORK_DIR}/ep_admin_keystone.json
+rm -f ${WORK_DIR}/ep_admin_swift.json
+rm -f ${WORK_DIR}/ep_internal_keystone.json
+rm -f ${WORK_DIR}/ep_internal_swift.json
+rm -f ${WORK_DIR}/ep_public_keystone.json
+rm -f ${WORK_DIR}/ep_public_swift.json
+
+echo "===> Finish !!!"
+

--- a/cookbooks/keystone/recipes/data.rb
+++ b/cookbooks/keystone/recipes/data.rb
@@ -13,39 +13,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bash 'register keystone initial data' do
-  user "root"
-  code <<-EOC
-    unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+if node['keystone_register_data_method'] == 'curl' then
+  cookbook_file '/tmp/register_keystone_initial_data.sh' do
+    mode 0744
+  end
 
-    # TODO
-    # According to Openstack Installation Guide, there is not necessary to
-    # create demo project/user but there is a problem if there is no
-    # demo project/user creation before admin project/user creation.
-    # So I put them for workaround.
-    openstack project create --description "Demo Project" demo
-    openstack user create --password demo_password demo --email demo@example.com --project demo
+  bash 'register swift initial data to keystone by curl' do
+    user "root"
+    code <<-EOC
+      unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+      sh /tmp/register_keystone_initial_data.sh
+      rm -f register_keystone_initial_data.sh
+    EOC
+  end
+else
+  bash 'register keystone initial data by openstack-client' do
+    user "root"
+    code <<-EOC
+      unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
 
-    openstack project create --description "Admin Project" admin
-    openstack user create --password admin_password admin --email admin@example.com --project admin
-    openstack role create admin
-    openstack role add --project admin --user admin admin
-    openstack project create --description "Service Project" service
-    openstack service create --type identity --description "OpenStack Identity" keystone
-    openstack endpoint create --publicurl http://127.0.0.1:5000/v2.0  --internalurl http://127.0.0.1:5000/v2.0  --adminurl http://127.0.0.1:35357/v2.0  --region RegionOne keystone
+      # TODO
+      # According to Openstack Installation Guide, there is not necessary to
+      # create demo project/user but there is a problem if there is no
+      # demo project/user creation before admin project/user creation.
+      # So I put them for workaround.
+      openstack project create --description "Demo Project" demo
+      openstack user create --password demo_password demo --email demo@example.com --project demo
 
-  EOC
-  environment "OS_TOKEN" =>'ADMIN', "OS_URL" =>'http://127.0.0.1:35357/v2.0'
+      openstack project create --description "Admin Project" admin
+      openstack user create --password admin_password admin --email admin@example.com --project admin
+      openstack role create admin
+      openstack role add --project admin --user admin admin
+      openstack project create --description "Service Project" service
+      openstack service create --type identity --description "OpenStack Identity" keystone
+      openstack endpoint create --publicurl http://127.0.0.1:5000/v2.0  --internalurl http://127.0.0.1:5000/v2.0  --adminurl http://127.0.0.1:35357/v2.0  --region RegionOne keystone
+
+    EOC
+    environment "OS_TOKEN" =>'ADMIN', "OS_AUTH_URL" =>'http://127.0.0.1:35357/v2.0'
+  end
+
+  bash 'register swift initial data to keystone' do
+    user "root"
+    code <<-EOC
+      unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+      openstack user create --password swift_password swift --email admin@example.com --project service
+      openstack role add --project service --user swift admin
+      openstack service create --type object-store --description "OpenStack Object Storage" swift
+      openstack endpoint create --publicurl 'http://127.0.0.1:8080/v1/AUTH_%(tenant_id)s'  --internalurl 'http://127.0.0.1:8080/v1/AUTH_%(tenant_id)s'  --adminurl 'http://127.0.0.1:8080' --region RegionOne swift
+    EOC
+    environment "OS_TOKEN" =>'ADMIN', "OS_AUTH_URL" =>'http://127.0.0.1:35357/v2.0'
+  end
 end
 
-bash 'register swift initial data to keystone' do
-  user "root"
-  code <<-EOC
-    unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
-    openstack user create --password swift_password swift --email admin@example.com --project service
-    openstack role add --project service --user swift admin
-    openstack service create --type object-store --description "OpenStack Object Storage" swift
-    openstack endpoint create --publicurl 'http://127.0.0.1:8080/v1/AUTH_%(tenant_id)s'  --internalurl 'http://127.0.0.1:8080/v1/AUTH_%(tenant_id)s'  --adminurl 'http://127.0.0.1:8080' --region RegionOne swift
-  EOC
-  environment "OS_TOKEN" =>'ADMIN', "OS_URL" =>'http://127.0.0.1:35357/v2.0'
-end

--- a/cookbooks/keystone/recipes/setup.rb
+++ b/cookbooks/keystone/recipes/setup.rb
@@ -62,18 +62,21 @@ execute "keystone-install" do
   action :run
 end
 
-execute "git python-openstackclient" do
-  cwd "#{node['source_root']}"
-  command "git clone -b #{node['openstackclient_repo_branch']} #{node['openstackclient_repo']}"
-  creates "#{node['source_root']}/python-openstackclient"
-  action :run
+if node['keystone_register_data_method'] != 'curl' then
+  execute "git python-openstackclient" do
+    cwd "#{node['source_root']}"
+    command "git clone -b #{node['openstackclient_repo_branch']} #{node['openstackclient_repo']}"
+    creates "#{node['source_root']}/python-openstackclient"
+    action :run
+  end
+
+  execute "python-openstackclient-install" do
+    cwd "#{node['source_root']}/python-openstackclient"
+    command "pip install -e . && pip install -r test-requirements.txt"
+    if not node['full_reprovision']
+      creates "/usr/local/lib/python2.7/dist-packages/python-openstackclient.egg-link"
+    end
+    action :run
+  end
 end
 
-execute "python-openstackclient-install" do
-  cwd "#{node['source_root']}/python-openstackclient"
-  command "pip install -e . && pip install -r test-requirements.txt"
-  if not node['full_reprovision']
-    creates "/usr/local/lib/python2.7/dist-packages/python-openstackclient.egg-link"
-  end
-  action :run
-end

--- a/localrc-template
+++ b/localrc-template
@@ -34,6 +34,7 @@ export KEYSTONEMIDDLEWARE_REPO=git://github.com/openstack/keystonemiddleware.git
 export KEYSTONEMIDDLEWARE_REPO_BRANCH=master
 export KEYSTONE_REPO=git://github.com/openstack/keystone.git
 export KEYSTONE_REPO_BRANCH=master
+export KEYSTONE_REGISTER_DATA_METHOD="openstack-client" # openstack-client or curl
 export OPENSTACKCLIENT_REPO=git://github.com/openstack/python-openstackclient.git
 export OPENSTACKCLIENT_REPO_BRANCH=master
 # environ options

--- a/scripts/endpoint_template.json
+++ b/scripts/endpoint_template.json
@@ -1,0 +1,9 @@
+{
+    "endpoint": {
+        "interface": "@INTERFACE@",
+        "name": "@NAME@",
+        "region_id": "@REGION_ID@",
+        "url": "@URL@",
+        "service_id": "@SERVICE_ID@"
+    }
+}

--- a/scripts/region_template.json
+++ b/scripts/region_template.json
@@ -1,0 +1,6 @@
+{
+    "region": {
+        "description": "@DESCRIPTION@",
+        "id": "@REGION_ID@"
+    }
+}

--- a/scripts/service_template.json
+++ b/scripts/service_template.json
@@ -1,0 +1,7 @@
+{
+    "service": {
+        "type": "@TYPE@",
+        "name": "@NAME@",
+        "description": "@DESCRIPTION@"
+    }
+}


### PR DESCRIPTION
Add the new method that registering the keystone initial data by curl command.
Usage:

(1) sed

<pre>
sed -e 's/KEYSTONE_AUTH_PROVISION=false/KEYSTONE_AUTH_PROVISION=true/' -e 's/KEYSTONE_REGISTER_DATA_METHOD="openstack-client"/KEYSTONE_REGISTER_DATA_METHOD="curl"/' -e 's+SOURCE_ROOT=/vagrant+SOURCE_ROOT=/home/vagrant+' localrc-template > localrc.keystone
</pre>


(2) vagrant up
