### PR TITLE
Pull in upstream master

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,7 +85,7 @@ Vagrant.configure("2") do |global_config|
         vb.name = "vagrant-#{hostname}-#{current_datetime}"
         vb.cpus = Integer(ENV['VAGRANT_CPUS'] || 1)
         vb.memory = Integer(ENV['VAGRANT_RAM'] || 1024)
-        if (ENV['GUI'] || false)  # Why is my VM hung on boot? Find out!
+        if (ENV['GUI'] || '').nil?  # Why is my VM hung on boot? Find out!
           vb.gui = true
         end
       end

--- a/bin/reinstallswift
+++ b/bin/reinstallswift
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
 cd /tmp/vagrant-chef*/
 sed 's/"full_reprovision": false/"full_reprovision": true/g' dna.json > reload.json
 sudo chef-solo -c solo.rb -j reload.json -o swift::source

--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -68,6 +68,17 @@ extra_packages = node['extra_packages']
   end
 end
 
+# no-no packages (PIP is the bomb, system packages are OLD SKOOL)
+unrequired_packages = [
+  "python-requests",  "python-six", "python-urllib3",
+  "python-pbr", "python-pip",
+]
+unrequired_packages.each do |pkg|
+  package pkg do
+    action :purge
+  end
+end
+
 # it's a brave new world
 execute "install pip" do
   command "curl https://bootstrap.pypa.io/get-pip.py | python"

--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -87,7 +87,7 @@ end
 
 # pip 8.0 is more or less broken on trusty -> https://github.com/pypa/pip/issues/3384
 execute "upgrade pip" do
-  command "pip install 'pip<8.0'"
+  command "pip install --upgrade 'pip>=8.0.2'"
 end
 
 execute "fix pip warning 1" do

--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -59,7 +59,7 @@ required_packages = [
   "curl", "gcc", "memcached", "rsync", "sqlite3", "xfsprogs", "git-core",
   "build-essential", "python-dev", "libffi-dev", "python3.3", "python3.3-dev",
   "python3.4", "python3.4-dev", "python2.6", "python2.6-dev", "libxml2-dev",
-  "libxml2", "libxslt1-dev",
+  "libxml2", "libxslt1-dev", "libssl-dev",
 ]
 extra_packages = node['extra_packages']
 (required_packages + extra_packages).each do |pkg|
@@ -74,13 +74,18 @@ execute "install pip" do
   not_if "which pip"
 end
 
+# pip 8.0 is more or less broken on trusty -> https://github.com/pypa/pip/issues/3384
 execute "upgrade pip" do
-  command "pip install --upgrade pip"
+  command "pip install 'pip<8.0'"
 end
 
 execute "fix pip warning 1" do
   command "sed '/env_reset/a Defaults\talways_set_home' -i /etc/sudoers"
   not_if "grep always_set_home /etc/sudoers"
+end
+
+execute "fix pip warning 2" do
+  command "pip install --upgrade ndg-httpsclient"
 end
 
 # setup environment

--- a/cookbooks/swift/recipes/setup.rb
+++ b/cookbooks/swift/recipes/setup.rb
@@ -54,7 +54,8 @@ end
 
 # packages
 required_packages = [
-  "libjerasure-dev",  # required for the EC biz
+  "libjerasure-dev", "liberasurecode-dev",  # required for the EC biz
+  "libssl-dev", # libssl-dev is required for building wheels from the cryptography package in swift.
   "curl", "gcc", "memcached", "rsync", "sqlite3", "xfsprogs", "git-core",
   "build-essential", "python-dev", "libffi-dev", "python3.3", "python3.3-dev",
   "python3.4", "python3.4-dev", "python2.6", "python2.6-dev", "libxml2-dev",


### PR DESCRIPTION
I tried to bring up a keystone-swift-all-in-one by following steps here:

https://github.com/osanai-hisashi/vagrant-swift-all-in-one/tree/keystone-auth#keystone-auth

... but it didn't work

```
==> default: [2016-01-27T21:46:44+00:00] INFO: execute[swift-bench-install] ran successfully
==> default:     
==> default: - execute pip install -e . && pip install -r test-requirements.txt
==> default:   * execute[python-swift-install] action run
==> default: 
==> default:     [execute] Obtaining file:///vagrant/swift
==> default:                   Complete output from command python setup.py egg_info:
==> default:                   error in setup command: Invalid environment marker: (python_version>='3.0')
==> default:                   
==> default:                   ----------------------------------------
==> default:               Command "python setup.py egg_info" failed with error code 1 in /vagrant/swift
==> default:     
==> default: 
==> default:     
==> default: ================================================================================
==> default:     
==> default: Error executing action `run` on resource 'execute[python-swift-install]'
==> default:     
==> default: ================================================================================
==> default:     
```

I think maybe this is already fixed on upstream master?
